### PR TITLE
Update Managed AD Prereqs

### DIFF
--- a/doc_source/ms_ad_getting_started_prereqs.md
+++ b/doc_source/ms_ad_getting_started_prereqs.md
@@ -18,6 +18,7 @@ To create a AWS Managed Microsoft AD directory, you need a VPC with the followin
 + The VPC must have default hardware tenancy\.
 + You cannot create a AWS Managed Microsoft AD in a VPC using addresses in the 198\.19\.0\.0/16 address space\.
 + AWS Directory Service does not support using Network Address Translation \(NAT\) with Active Directory\. Using NAT can result in replication errors\.
++ AWS Managed Microsoft AD directory does not currently support running in a VPC with a CloudWatch Monitoring VPC Endpoint and Private DNS enabled\.
 
 ## Multi\-factor Authentication Prerequisites<a name="prereq_mfa_ad"></a>
 


### PR DESCRIPTION
*Description of changes:*
Discovered that AWS Managed AD doesn't work with the CloudWatch Monitoring VPC endpoint as per AWS Support Case ID 5754329611. Updating Managed AD prerequisites so that others can be aware of this limitation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
