### PR TITLE
Correct typo in PowerShell command

### DIFF
--- a/doc_source/ms_ad_install_ad_tools.md
+++ b/doc_source/ms_ad_install_ad_tools.md
@@ -7,7 +7,7 @@ To manage your directory from an EC2 Windows instance, you need to install the A
 + [Install the Active Directory Administration Tools on Windows Server 2012](#install_ad_tools_win2012)
 + [Install the Active Directory Administration Tools on Windows Server 2016](#install_ad_tools_win2016)
 
-You can optionally choose to install the Active Directory administration tools using Windows PowerShell\. For example, you can install the Active Directory remote administration tools from a PowerShell prompt using `Install-WindowsFeature RSAD-ADDS`\. For more information, see [Install\-WindowsFeature](https://docs.microsoft.com/en-us/powershell/module/servermanager/install-windowsfeature?view=winserver2012r2-ps) on the Microsoft Website\.
+You can optionally choose to install the Active Directory administration tools using Windows PowerShell\. For example, you can install the Active Directory remote administration tools from a PowerShell prompt using `Install-WindowsFeature RSAT-ADDS`\. For more information, see [Install\-WindowsFeature](https://docs.microsoft.com/en-us/powershell/module/servermanager/install-windowsfeature?view=winserver2012r2-ps) on the Microsoft Website\.
 
 ## Install the Active Directory Administration Tools on Windows Server 2008<a name="install_ad_tools_win2008"></a>
 

--- a/doc_source/simple_ad_install_ad_tools.md
+++ b/doc_source/simple_ad_install_ad_tools.md
@@ -7,7 +7,7 @@ To manage your directory from an EC2 Windows instance, you need to install the A
 + [Install the Active Directory Administration Tools on Windows Server 2012](#install_ad_tools_win2012)
 + [Install the Active Directory Administration Tools on Windows Server 2016](#install_ad_tools_win2016)
 
-You can optionally choose to install the Active Directory administration tools using Windows PowerShell\. For example, you can install the Active Directory remote administration tools from a PowerShell prompt using `Install-WindowsFeature RSAD-ADDS`\. For more information, see [Install\-WindowsFeature](https://docs.microsoft.com/en-us/powershell/module/servermanager/install-windowsfeature?view=winserver2012r2-ps) on the Microsoft Website\.
+You can optionally choose to install the Active Directory administration tools using Windows PowerShell\. For example, you can install the Active Directory remote administration tools from a PowerShell prompt using `Install-WindowsFeature RSAT-ADDS`\. For more information, see [Install\-WindowsFeature](https://docs.microsoft.com/en-us/powershell/module/servermanager/install-windowsfeature?view=winserver2012r2-ps) on the Microsoft Website\.
 
 ## Install the Active Directory Administration Tools on Windows Server 2008<a name="install_ad_tools_win2008"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Correct typo in PowerShell command

*invalid args w/ rsad-adds*
```
PS C:\Users\Administrator> Install-WindowsFeature RSAD-ADDS
Install-WindowsFeature : ArgumentNotValid: The role, role service, or feature name is not valid: 'RSAD-ADDS'. The name
was not found.
At line:1 char:1
+ Install-WindowsFeature RSAD-ADDS
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (RSAD-ADDS:String) [Install-WindowsFeature], Exception
    + FullyQualifiedErrorId : NameDoesNotExist,Microsoft.Windows.ServerManager.Commands.AddWindowsFeatureCommand

Success Restart Needed Exit Code      Feature Result
------- -------------- ---------      --------------
False   No             InvalidArgs    {}
```

*success w/ rsat-adds*
```
PS C:\Users\Administrator> Install-WindowsFeature RSAT-ADDS

Success Restart Needed Exit Code      Feature Result
------- -------------- ---------      --------------
True    No             Success        {Remote Server Administration Tools, Activ...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.