### PR TITLE
highlight that directory should be in master account 

### DIFF
--- a/doc_source/step2_share_directory.md
+++ b/doc_source/step2_share_directory.md
@@ -16,7 +16,7 @@ Use the following procedures to begin the directory sharing workflow from within
 
 1. On the **Choose which AWS accounts to share with** page, choose one of the following sharing methods depending on your business needs:
 
-   1. **Share this directory with AWS accounts inside your organization** – With this option you can select the AWS accounts you want to share your directory with from a list showing all the AWS accounts inside your AWS organization\. You must enable trusted access with AWS Directory Service before you share a directory\. For more information, see [How to Enable or Disable Trusted Access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html#orgs_how-to-enable-disable-trusted-access)\.
+   1. **Share this directory with AWS accounts inside your organization** – With this option you can select the AWS accounts you want to share your directory with from a list showing all the AWS accounts inside your AWS organization\. You must enable trusted access with AWS Directory Service before you share a directory\. For more information, see [How to Enable or Disable Trusted Access](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services.html#orgs_how-to-enable-disable-trusted-access)\. Please note that, to use this option, AWS Organizations **must have All features enabled**, and your directory **must be in the organization master account**.
 
       1. Under **AWS accounts in your organization**, select the AWS accounts that you want to share the directory with and click **Add**\. 
 


### PR DESCRIPTION


*Issue #, if available:*

Share this directory with AWS accounts inside your organization is only possible if the directory is in the master account

*Description of changes:*

It looks like it's not possible to share a directory service with accounts in organization if the directory server is not in the master account.
That's clearly noted in the inline documentation for the service in Console (when you actually try to enable it) but it's not highlighted here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
