### PR TITLE
update doc to specifically include rhel 7

### DIFF
--- a/doc_source/seamlessly_join_linux_instance.md
+++ b/doc_source/seamlessly_join_linux_instance.md
@@ -5,7 +5,7 @@ This procedure seamlessly joins a Linux EC2 instance to your AWS Managed Microso
 The following Linux instance distributions and versions are supported:
 + Amazon Linux AMI 2018\.03\.0
 + Amazon Linux 2 \(64\-bit x86\)
-+ Red Hat Enterprise Linux 8 \(HVM\) \(64\-bit x86\)
++ Red Hat Enterprise Linux 7 & Red Hat Enterprise Linux 8 \(HVM\) \(64\-bit x86\)
 + Ubuntu Server 18\.04 LTS & Ubuntu Server 16\.04 LTS
 + CentOS 7 x86\-64
 + SUSE Linux Enterprise Server 15 SP1


### PR DESCRIPTION
Both amazon linux 2 and centos 7 are supported. The doc also mentions distro prior to rhel 7 not supported.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
